### PR TITLE
Calculating and storing team score, interpolating ghost train scores

### DIFF
--- a/client/src/components/CreateGame/Lobby/Rounds/Rounds.tsx
+++ b/client/src/components/CreateGame/Lobby/Rounds/Rounds.tsx
@@ -68,7 +68,7 @@ function Rounds(props: Props) {
         newAvailableRounds.splice(removeIndex, 1)
         setUnselectedRounds(curr => [...newAvailableRounds])
 
-        props.onRoundSelected(selectedRounds)
+        props.onRoundSelected(newSelectedRounds)
         props.onStepCompleted(true)
     }
 
@@ -81,7 +81,7 @@ function Rounds(props: Props) {
         newSelectedRounds.splice(removeIndex, 1)
         setSelectedRounds(curr => [...newSelectedRounds])
 
-        props.onRoundSelected(selectedRounds)
+        props.onRoundSelected(newSelectedRounds)
         if (selectedRounds.length == 0) props.onStepCompleted(false)  
     }
 

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
+        "curve-interpolator": "^3.3.1",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "jest-junit": "^16.0.0",

--- a/server/src/__tests__/scoreDBController.test.ts
+++ b/server/src/__tests__/scoreDBController.test.ts
@@ -15,7 +15,7 @@ describe("scoreDBController tests", () => {
         jest.spyOn(Score, "create").mockResolvedValueOnce(mockScore as any)
 
         const teamname = "Team A"
-        const score = 100
+        const score = [100]
         const checkpoints = [1, 2, 3]
         const roundId = "round123"
         const roundDuration = 600

--- a/server/src/controllers/scoreDBController.ts
+++ b/server/src/controllers/scoreDBController.ts
@@ -5,7 +5,7 @@ const { MongoClient } = require("mongodb")
 
 export async function saveNewScore(
     teamname: string,
-    score: number,
+    score: number[],
     checkpoints: number[],
     roundId: string,
     roundDuration: number,
@@ -83,7 +83,7 @@ export async function getGhostTrainScores(roundId: number) {
                 {
                     $group: {
                         _id: null,
-                        maxScore: { $max: "$score" },
+                        maxScore: { $max: { $last: "$score"} },
                         teamName: { $first: "$teamname" },
                     },
                 },
@@ -98,7 +98,7 @@ export async function getGhostTrainScores(roundId: number) {
                 {
                     $group: {
                         _id: null,
-                        averageScore: { $avg: "$score" },
+                        averageScore: { $avg: { $last: "$score"} },
                     },
                 },
             ])

--- a/server/src/models/scoreModel.ts
+++ b/server/src/models/scoreModel.ts
@@ -2,7 +2,7 @@ import mongoose from "mongoose"
 
 export interface IScore extends mongoose.Document {
     teamname: string
-    score: number
+    scores: number[]
     checkpoints: number[]
     roundId: string
     roundDuration: number
@@ -15,14 +15,14 @@ export const scoreSchema: mongoose.Schema = new mongoose.Schema({
         type: String,
         required: true,
     },
-    // Final score of the team after the full 10 min round
-    score: {
-        type: Number,
+    // Scores of the team recorded every 30sec
+    scores: {
+        type: [Number],
         required: true,
     },
     // Used to compare teams between each other when they reach a checkpoint
     checkpoints: {
-        // For each checkpoint, we store how many pts a team has at the checkpoint's time
+        // For each checkpoint, we store how many pts a team has at the checkpoint's time   
         type: [Number],
         required: true,
     },

--- a/server/src/objects/gameObject.ts
+++ b/server/src/objects/gameObject.ts
@@ -210,6 +210,17 @@ export class Game {
     }
 
     /**
+     * Calculates the value for the team score which is to be stored in the database
+     * @param teamScore sumed value of the team score
+     * @param numberOfPlayers total number of players in the game
+     * @param roundDuration the duration of the round being played
+     * @returns the score value to store in the database
+     */
+    calculateDatabaseScoreValue(teamScore: number, numberOfPlayers: number, roundDuration: number) {
+        return teamScore / (numberOfPlayers * roundDuration)
+    }
+
+    /**
      * Helper function to check if the mandatory questions are done for a user
      * @param socketId the player to check for
      * @returns if user has already asnwered x mandatory questions

--- a/server/src/socketConnection.ts
+++ b/server/src/socketConnection.ts
@@ -46,7 +46,9 @@ module.exports = {
 
                     game.avgScore = game.totalScore / game.users.size
 
-                    io.to(`lecturer${lobbyId}`).emit("score", game.avgScore)
+                    io.to(`lecturer${lobbyId}`).emit("score", {
+                        score: Math.floor(game.totalScore),
+                    })
 
                 } catch (error) {
                     //If an error is throw it means the game was not started yet
@@ -110,7 +112,9 @@ module.exports = {
                     game.users.delete(socket.id)
                     game.avgScore = game.totalScore / game.users.size
 
-                    io.to(`lecturer${lobbyId}`).emit("score", game.avgScore)
+                    io.to(`lecturer${lobbyId}`).emit("score", {
+                        score: Math.floor(game.totalScore),
+                    })
                 } catch (error) {
                     console.log(error)
                     //If an error is throw it means the game was not started yet
@@ -136,7 +140,9 @@ module.exports = {
                     startLobby(lobbyId)
                     try {
                         console.log(study)
+                        console.log(topics)
                         const rounds = await getIRounds(study, topics)
+                        console.log(rounds)
                         if (io.sockets.adapter.rooms.get(`players${lobbyId}`).size == 0) return
                         const socketIds: string[] = io.sockets.adapter.rooms.get(
                             `players${lobbyId}`
@@ -199,7 +205,7 @@ module.exports = {
                         if (game.isMandatoryDone(socket.id)) socket.emit("chooseDifficulty")
                         const accuracy = (game.correct / (game.incorrect + game.correct)) * 100
                         io.to(`lecturer${lobbyId}`).emit("score", {
-                            score: Math.floor(game.avgScore),
+                            score: Math.floor(game.totalScore),
                             accuracy: Math.floor(accuracy),
                         })
                     } else if (attempts === 0) {

--- a/server/src/socketConnection.ts
+++ b/server/src/socketConnection.ts
@@ -255,7 +255,7 @@ module.exports = {
 
                 await saveNewScore(
                     game.teamName,
-                    game.avgScore,
+                    game.timeScores,
                     game.checkpoints,
                     game.rounds[game.round]._id,
                     game.roundDurations[game.round],
@@ -266,6 +266,16 @@ module.exports = {
 
                 const result = await getAllScores(currentRound.id)
                 socket.emit("get-all-scores", result)
+            })
+
+            /**
+             * This function saves a new time score when called by frontend
+             * The time score is taken from the current team score after applying normalization
+             */
+            socket.on("saveTimeScore", () => {
+                const lobbyId = socketToLobbyId.get(socket.id)!
+                const game = getGame(lobbyId)
+                game.addNewTimeScore()
             })
 
             /**


### PR DESCRIPTION
- Changed how scores are stored in the database: now a list of values recorded every delta t seconds
- Added functionality for saving new time score, which is utilized by frontend
- Added interpolation of ghost train scores along with transformation from normalized form to the form appropriate for the current round (multiplied by number of players and round duration)