### PR TITLE
Add binning and team sampling for ghost teams

### DIFF
--- a/client/src/components/CreateGame/Lecturer/Lecturer.tsx
+++ b/client/src/components/CreateGame/Lecturer/Lecturer.tsx
@@ -172,11 +172,16 @@ function Lecturer(props: Props) {
             setTeamScores(curr => [...formattedTeamScores])
             setShowLeaderBoard(curr => true)
         })
+
+        socket.on("ghost-teams", (ghostTeams: JSON[]) => {
+            console.log(ghostTeams)
+        })
     }, [socket])
 
     //reset everything when new round start
     const startNewRound = () => {
         socket.emit("startNextRound")
+        socket.emit("getGhostTeams")
 
         //if no more rounds, end game
         if (gameEnds) {

--- a/client/src/components/CreateGame/Lobby/Lobby.tsx
+++ b/client/src/components/CreateGame/Lobby/Lobby.tsx
@@ -53,7 +53,7 @@ function Lobby(props: Props) {
             selectedStudy.toUpperCase(),
             teamName
         )
-        socket.emit("getGhostTrains")
+        socket.emit("getGhostTeams")
     }
 
     // Converts the lobby id to string and padds it with 0s if necessary to obtain a 4 number code

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,8 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
+        "@stdlib/random-sample": "^0.1.0",
+        "@stdlib/random-shuffle": "^0.1.0",
         "curve-interpolator": "^3.3.1",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",

--- a/server/src/controllers/scoreDBController.ts
+++ b/server/src/controllers/scoreDBController.ts
@@ -1,7 +1,10 @@
+import type { ObjectId } from "mongodb"
 import { Score } from "../models/scoreModel"
 import type { IScore } from "../models/scoreModel"
 
 const { MongoClient } = require("mongodb")
+const sample = require( '@stdlib/random-sample' );
+const shuffle = require( '@stdlib/random-shuffle' );
 
 export async function saveNewScore(
     teamname: string,
@@ -59,6 +62,115 @@ export async function getCheckpoints(
     } catch (error) {
         throw error
     }
+}
+
+/**
+ * Gets the average score and best score for the chosen round
+ * @param roundId the selected round
+ * @returns the average score and best score
+ */
+async function getBestTeams(roundId: string, numberOfTeams: number) {
+    try {
+        const client = new MongoClient(process.env.MONGO_URL as string)
+        await client.connect()
+
+        const db = client.db()
+        const scores = db.collection("scores")
+
+        const bestTeams = await scores.aggregate([
+            {
+                $match: { roundId: roundId },
+            },
+            {
+              $addFields: {
+                lastElement: { $arrayElemAt: ["$scores", -1] } // Extract the last element of the array
+              }
+            },
+            {
+              $sort: {
+                lastElement: -1 // Sort based on the last element in descending order
+              }
+            },
+            {
+              $limit: numberOfTeams // Get the top 'numberOfTeams' teams
+            }
+          ]).toArray()
+
+        return bestTeams
+    } catch (error) {
+        console.log(error)
+    }
+}
+
+/**
+ * Creates equally sized bins depending on the team score over the teams that played the round
+ * @param roundId the id of the current round
+ * @param numberOfBins number of bins to create
+ * @param excludeTeamIds ids of teams to exclude from the bins
+ * @returns equally sized bins based on team scores
+ */
+async function getBinsOfTeams(roundId: string, numberOfBins: number, excludeTeamIds?: ObjectId[]) {
+    try {
+        const client = new MongoClient(process.env.MONGO_URL as string)
+            await client.connect()
+
+            const db = client.db()
+            const scores = db.collection("scores")
+
+        const res = await scores.aggregate([
+            {
+            $match: {
+                roundId: roundId,
+                _id: { $nin: excludeTeamIds ? excludeTeamIds : [] }
+            }
+            },
+            {
+            $addFields: {
+                lastElement: { $arrayElemAt: ["$scores", -1] } // Get the last element from the scores array
+            }
+            },
+            {
+            $bucketAuto: {
+                groupBy: "$lastElement",
+                buckets: numberOfBins, // Create 5 buckets
+                output: {
+                documents: { $push: "$$ROOT" } // Store the entire documents in each bucket
+                }
+            }
+            }
+        ]).toArray()
+
+        return res
+    } catch(error) {
+        console.log(error)
+    }
+}
+
+/**
+ * Get ghost teams for current round, by taking the top 3 teams and binning + sampling the rest
+ * @param roundId id of the current round
+ * @returns ghost teams for current round
+ */
+export async function getGhostTeams(roundId: number) {
+    const config = {
+        numberOfTopTeamsToGet: 3, // Currently we take top 3 teams fixed
+        numberOfTeamsToRandomlySample: 15, // We randomly sample for 15 additional teams (with binning)
+        numberOfBins: 5 // Number of bins to create before sampling
+    }
+    const roundIdStr: string = roundId.toString()
+
+    const bestTeams = await getBestTeams(roundIdStr, config.numberOfTopTeamsToGet)
+    const bestTeamIds = bestTeams.map(x => x._id)
+    let ghostTeams = bestTeams
+
+    const teamBins = await getBinsOfTeams(roundIdStr, config.numberOfBins, bestTeamIds)
+
+    for (const bin of teamBins) {
+        const sampledTeams = sample(bin.documents, {size: 3, replace: false})
+        ghostTeams = ghostTeams.concat(sampledTeams)
+    }
+
+    return shuffle(ghostTeams)
 }
 
 /**

--- a/server/src/objects/gameObject.ts
+++ b/server/src/objects/gameObject.ts
@@ -218,7 +218,7 @@ export class Game {
      */
     addNewTimeScore() {
         const currentTotalScore = this.totalScore
-        const numberOfPlayers = this.users.keys.length
+        const numberOfPlayers = this.users.size
         const roundDuration = this.roundDurations[this.round]
 
         const newTimeScore = currentTotalScore / (numberOfPlayers * roundDuration)
@@ -235,7 +235,9 @@ export class Game {
         const points = ghostTeamScores.map((x, index) => [index * 30, x])
         const interp = new CurveInterpolator(points, { tension: 0.2, alpha: 0.5 });
         const newPoints = interp.getPoints(this.roundDurations[this.round] / deltaT)
-        return this.transformGhostTeamScoresForCurrentRound(newPoints)
+        const result = this.transformGhostTeamScoresForCurrentRound(newPoints)
+        
+        return result
     }
 
     /**
@@ -245,7 +247,7 @@ export class Game {
      * @returns the scaled up values for the scores based on current number of players and round duration
      */
     transformGhostTeamScoresForCurrentRound(ghostTeamScores: number[][]) {
-        return ghostTeamScores.map(x => x[1] * this.users.keys.length * this.roundDurations[this.round])
+        return ghostTeamScores.map(x => x[1] * this.users.size * this.roundDurations[this.round])
     }
 
     /**


### PR DESCRIPTION
- Create a list of 18 teams (currently 18, can be changed in config) that previously played the round; this includes the top 3 teams and the other 15 teams are randomly sampled from 5 bins (bins created based on final score)
- Add socket endpoint to retrieve these teams along with performing interpolation on their score