### PR TITLE
Finish new ghost team implementation

### DIFF
--- a/client/src/components/CreateGame/Lecturer/Lecturer.tsx
+++ b/client/src/components/CreateGame/Lecturer/Lecturer.tsx
@@ -216,8 +216,8 @@ function Lecturer(props: Props) {
                 >
                     <RaceTheme
                         selectedTheme={props.theme}
-                        maxPoints={1000}
-                        averageGoalPoints={500}
+                        maxPoints={2000}
+                        averageGoalPoints={2000}
                         currentPoints={score}
                         mapDimensions={{ width: width, height: height - 100 }}
                         checkpoints={LecturerService.getCheckpointsForTheme(props.theme)}

--- a/client/src/components/RaceThemes/BoatTheme/BoatTheme.tsx
+++ b/client/src/components/RaceThemes/BoatTheme/BoatTheme.tsx
@@ -114,6 +114,7 @@ function BoatTheme(props: Props) {
                                       props.averageGoalPoints
                             }
                             ghostBoats={props.ghosts}
+                            usedTime={props.usedTime}
                             finalSection={currentMapSection == 1}
                             mapDimensions={props.mapDimensions}
                             trackPoints={section.path}

--- a/client/src/components/RaceThemes/BoatTheme/Path/Path.tsx
+++ b/client/src/components/RaceThemes/BoatTheme/Path/Path.tsx
@@ -20,6 +20,7 @@ interface Props {
     totalPoints: number // number of points needed to complete the map section
     currentPoints: number // current points of the team
     checkpoints: Checkpoint[] // list of checkpoints
+    usedTime: number    // current round time
     ghostBoats: Ghost[] // list of ghost boats
     finalSection: boolean // boolean to indicate whether this is the final section of the map
     onSectionComplete: () => void // event called when the end of the map is reached
@@ -125,10 +126,10 @@ function Path(props: Props) {
                 <Ghosts
                     data-testid={"ghosts"}
                     ghosts={props.ghostBoats}
-                    totalPoints={props.totalPoints}
-                    colors={ghostColors}
+                    time={props.usedTime}
                     path={svgPath}
                     sprite={Sprites.boat}
+                    totalPoints={props.totalPoints}
                 />
             )}
         </div>

--- a/client/src/components/RaceThemes/Ghosts/BestGhost.tsx
+++ b/client/src/components/RaceThemes/Ghosts/BestGhost.tsx
@@ -16,9 +16,7 @@ function BestGhost(props: Props) {
             style={{
                 borderColor: "#FFD700",
                 offsetPath: `path("${props.path}")`,
-                offsetDistance: `${
-                    (props.bestGhost.score / props.totalPoints) * 100
-                }%`,
+                offsetDistance: "0%",
             }}
         >
             <div className="highest-score">HIGHEST SCORE</div>

--- a/client/src/components/RaceThemes/Ghosts/Ghosts.tsx
+++ b/client/src/components/RaceThemes/Ghosts/Ghosts.tsx
@@ -1,16 +1,51 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { Ghost } from "../SharedUtils"
 import { motion } from "framer-motion"
 
+
+interface GhostAnimation {
+    pathProgress: number    // current progress along the race path (percentage)
+    transitionDuration: number  // duration of transition animation
+    timeScoreIndex: number  // index of the time score the ghost is reaching next
+}
 interface Props {
     ghosts: Ghost[] // list of ghosts to display
-    totalPoints: number // total points required to complete the map
-    colors: string[] // list of colors for the ghosts
     path: string // svg path for the ghosts to take
+    totalPoints: number // total points required to reach the end of the map
     sprite: string // sprite to use for the ghosts icon
+    time: number // current round time
 }
 
 function Ghosts(props: Props) {
+    const [animations, setAnimations] = useState<GhostAnimation[]>(
+        new Array(18).fill(0).map(x => (
+            {
+                pathProgress: 0,    // initialize all ghost to progress of 0%
+                transitionDuration: 1,  // transition duration initalized at 1, changes when updating
+                timeScoreIndex: 0   // intialize index to 0, so the ghost first aims to reach its first time score
+            })))
+
+    useEffect(() => {
+        const newAnimations = animations
+        if (!props.ghosts || props.ghosts.length != animations.length) return
+        for (let i = 0; i < newAnimations.length; i++) {
+            // Introduce constants to reduce code repetition
+            const currentTimeScoreIndex = animations[i].timeScoreIndex
+            const currentGhostTimePoint = props.ghosts[i].timeScores[currentTimeScoreIndex].timePoint
+            const currentGhostNewScore = props.ghosts[i].timeScores[currentTimeScoreIndex].score
+
+            // If the time matches a ghost's time point, it is time to update its score (make it move) 
+            if (currentGhostTimePoint == props.time) {
+                newAnimations[i] = {
+                    pathProgress: Math.floor((currentGhostNewScore / props.totalPoints) * 100), // progress determined as the ratio of points and total points
+                    transitionDuration: Math.floor(Math.random() * 5) + 1,  // randomize duration of animation between 1 and 5 seconds, for more variation
+                    timeScoreIndex: currentTimeScoreIndex == props.ghosts[i].timeScores.length ? currentTimeScoreIndex : currentTimeScoreIndex + 1  // increase index unless last score reached
+                }
+            }
+        }
+        setAnimations(curr => [...newAnimations])
+    }, [props.time])
+
     return (
         <div>
             {props.ghosts.map((ghost, index) => (
@@ -19,21 +54,21 @@ function Ghosts(props: Props) {
                     key={index}
                     className="progress-point rounded-circle ghost"
                     style={{
-                        borderColor: props.colors[index],
+                        borderColor: ghost.color,
                         offsetPath: `path("${props.path}")`,
                     }}
                     initial={{ offsetDistance: "0%" }}
-                    animate={{ offsetDistance: "100%" }}
+                    animate={{ offsetDistance: animations[index].pathProgress.toString() + "%" }}
                     transition={{
-                        duration: (props.totalPoints * 600) / ghost.score,
+                        duration: animations[index].transitionDuration,
                         stiffness: 100,
                     }}
                 >
                     <div
                         className="name"
                         style={{
-                            color: props.colors[index],
-                            borderBottomColor: props.colors[index],
+                            color: ghost.color,
+                            borderBottomColor: ghost.color,
                         }}
                     >
                         {ghost.teamName}

--- a/client/src/components/RaceThemes/RaceTheme.tsx
+++ b/client/src/components/RaceThemes/RaceTheme.tsx
@@ -23,26 +23,19 @@ function RaceTheme(props: Props) {
     const [ghosts, setGhosts] = useState<Ghost[]>([])
 
     useEffect(() => {
-        socket.emit("getGhostTrains")
-    }, [])
+        socket.emit("getGhostTeams")
+    }, [props.averageGoalPoints])
 
     useEffect(() => {
-        socket.on("ghost-trains", (ghosts) => {
-            const averageGhost = ghosts["avgScore"][0]
-            const bestGhost = ghosts["bestScore"][0]
+        socket.on("ghost-teams", (ghosts) => {
+            const ghostsWithColor: Ghost[] = ghosts.map(
+                (x: { teamName: string; timeScores: { timePoint: number, score: number }; checkpoints: number[]; study: string; accuracy: number }) => ({
+                    ...x,
+                    color: "#" + Math.random().toString(16).substring(2, 8)
+                }))
 
-            const newGhosts = [
-                {
-                    score: averageGhost["averageScore"],
-                    teamName: "AverageJoes",
-                },
-                {
-                    score: bestGhost["maxScore"],
-                    teamName: bestGhost["teamName"],
-                },
-            ]
-
-            setGhosts((curr) => [...newGhosts])
+            setGhosts((curr) => [...ghostsWithColor])
+            console.log(ghosts)
         })
     }, [socket])
 

--- a/client/src/components/RaceThemes/SharedUtils.ts
+++ b/client/src/components/RaceThemes/SharedUtils.ts
@@ -14,8 +14,12 @@ class Point {
 }
 
 interface Ghost {
-    score: number
     teamName: string
+    color: string
+    timeScores: { timePoint: number, score: number }[]
+    checkpoints: number[]
+    study: string
+    accuracy: number
 }
 
 interface Checkpoint {

--- a/client/src/components/RaceThemes/TrainTheme/Tracks/Tracks.tsx
+++ b/client/src/components/RaceThemes/TrainTheme/Tracks/Tracks.tsx
@@ -21,6 +21,7 @@ interface Props {
     trackPoints: PercentCoordinate[] // list of path corner points
     totalPoints: number // number of points needed to complete the map section
     currentPoints: number // current points of the team
+    usedTime: number    // current round time
     checkpoints: Checkpoint[] // list of checkpoints
     ghostTrains: Ghost[] // list of ghost boats
     finalSection: boolean // boolean to indicate whether this is the final section of the map
@@ -135,10 +136,10 @@ function Tracks(props: Props) {
                 <Ghosts
                     data-testid={"ghosts"}
                     ghosts={props.ghostTrains}
-                    totalPoints={props.totalPoints}
-                    colors={ghostColors}
+                    time={props.usedTime}
                     path={svgPath}
                     sprite={Sprites.train}
+                    totalPoints={props.totalPoints}
                 />
             )}
         </div>

--- a/client/src/components/RaceThemes/TrainTheme/TrainTheme.tsx
+++ b/client/src/components/RaceThemes/TrainTheme/TrainTheme.tsx
@@ -122,6 +122,7 @@ function TrainTheme(props: Props) {
                                       props.averageGoalPoints
                             }
                             ghostTrains={props.ghosts}
+                            usedTime={props.usedTime}
                             finalSection={currentMapSection == 1}
                             mapDimensions={props.mapDimensions}
                             trackPoints={section.tracks}

--- a/server/src/socketConnection.ts
+++ b/server/src/socketConnection.ts
@@ -279,6 +279,9 @@ module.exports = {
                 game.addNewTimeScore()
             })
 
+            /**
+             * Gets randomly sampled ghost teams, applies interpolation and sends them to client
+             */
             socket.on("getGhostTeams", async () => {
                 try {
                     const lobbyId = socketToLobbyId.get(socket.id)!
@@ -290,12 +293,11 @@ module.exports = {
                     const ghostTeams = await getGhostTeams(roundId)
                     const interpolatedGhostTeams = ghostTeams.map(x => ({
                         teamName: x.teamname,
-                        scores: game.getInterpolateGhostTeamScoreForCurrentGame(x.scores, 30),
+                        timeScores: game.getGhostTeamTimePointScores(x.scores),
                         checkpoints: x.checkpoints,
                         study: x.study,
                         accuracy: x.accuracy
                     }))
-                    console.log("SENDIng...")
                     socket.emit("ghost-teams", interpolatedGhostTeams)
                 } catch (error) {
                     console.log(error)


### PR DESCRIPTION
- Updated interpolation method on backend: now for each ghost team an array of time score objects is sent, containing a time value at which to update the score and the score of that team at that time (calculated using cubic interpolation of the recorded ghost scores)
- The ghost teams are displayed on frontend; each team has random times at which an update in its position occurs, to more accurately simulate their progress (instead of a constant smooth movement, the movement is jumpy and in segments, as the score is realistically increased every fixed amount of time when a question is answered rather than being continuous).
- Along with the random update times, the animation durations are also randomized between 1 and 5 seconds for further variation and a more entertaining race