### PR TITLE
Fix bug with saving scores to the database

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -227,6 +227,14 @@ function App() {
     //     }
     // }, [timeUsed, endOfRound])
 
+    useEffect(() => {
+        // Saves the current team score every 30 seconds, later interpolated to simulate this team's performance
+        // in other team's games in the form of a ghost
+        if (!isPlayer && totalSeconds % 30 == 0) {
+            socket.emit("saveTimeScore")
+        } 
+    }, [totalSeconds])
+
     return (
         <div className="App">
             <Routes>

--- a/server/src/controllers/scoreDBController.ts
+++ b/server/src/controllers/scoreDBController.ts
@@ -8,7 +8,7 @@ const shuffle = require( '@stdlib/random-shuffle' );
 
 export async function saveNewScore(
     teamname: string,
-    score: number[],
+    scores: number[],
     checkpoints: number[],
     roundId: string,
     roundDuration: number,
@@ -17,7 +17,7 @@ export async function saveNewScore(
 ) {
     const newScore: IScore = new Score({
         teamname,
-        score,
+        scores,
         checkpoints,
         roundId,
         roundDuration,

--- a/server/src/models/scoreModel.ts
+++ b/server/src/models/scoreModel.ts
@@ -19,6 +19,7 @@ export const scoreSchema: mongoose.Schema = new mongoose.Schema({
     scores: {
         type: [Number],
         required: true,
+        default: undefined
     },
     // Used to compare teams between each other when they reach a checkpoint
     checkpoints: {

--- a/server/src/objects/gameObject.ts
+++ b/server/src/objects/gameObject.ts
@@ -34,7 +34,7 @@ export class Game {
         this.teamName = teamName
         this.avgScore = 0
         this.totalScore = 0
-        this.timeScores = [0]
+        this.timeScores = []
         this.users = users
         this.checkpoints = []
         this.study = study


### PR DESCRIPTION
- Added missing frontend emit to periodically record the current team score, which is then normalized to be stored in the database for later use (when the current team will act as a ghost team in future rounds)
- Fixed bug in naming that was causing the scores to be left out from saving to the database
- Changed initial value of the scores array to `[]` from `[0]`, as the first save occurs at the start of the round and thus achieves the same thing (score is 0 at the start)