### PR TITLE
Adjust looping animation approach

### DIFF
--- a/client/src/components/RaceThemes/Ghosts/GhostVehicle/GhostVehicle.tsx
+++ b/client/src/components/RaceThemes/Ghosts/GhostVehicle/GhostVehicle.tsx
@@ -91,12 +91,17 @@ function GhostVehicle(props: Props) {
             const currentGhostNewScore = props.ghost.timeScores[currentTimeScoreIndex].score
             const progress = (currentGhostNewScore/ props.totalPoints) * 100 // progress determined as the ratio of points and total points
         
+            const currentGhostPreviousScore = props.ghost.timeScores[Math.max(currentTimeScoreIndex - 1, 0)].score
+            const previousProgress = (currentGhostPreviousScore/ props.totalPoints) * 100 
 
-            animationControls.start({  
-                offsetDistance: progress.toString() + "%",
-                transition: {duration: 2}
-            })
-            updateGhostValues(currentTimeScoreIndex, currentGhostNewScore, progress)
+            // Prevent possible bug of team going backwards due to miscalculations / incorrect score storing
+            if (progress >= previousProgress) {
+                animationControls.start({  
+                    offsetDistance: progress.toString() + "%",
+                    transition: {duration: 2}
+                })
+                updateGhostValues(currentTimeScoreIndex, currentGhostNewScore, progress)
+            }
         }
     }, [startAnimation])
 

--- a/client/src/components/RaceThemes/Ghosts/GhostVehicle/GhostVehicle.tsx
+++ b/client/src/components/RaceThemes/Ghosts/GhostVehicle/GhostVehicle.tsx
@@ -89,33 +89,14 @@ function GhostVehicle(props: Props) {
             if (currentTimeScoreIndex == -1) return // if the time score index was reset to -1, no more animations should be played
 
             const currentGhostNewScore = props.ghost.timeScores[currentTimeScoreIndex].score
-            const progress = ((currentGhostNewScore % props.totalPoints) / props.totalPoints) * 100 // progress determined as the ratio of points and total points
+            const progress = (currentGhostNewScore/ props.totalPoints) * 100 // progress determined as the ratio of points and total points
         
-            // Since the ghosts can't move backwards, if the new progress value is smaller than the old, it means we are in a new race lap
-            if (props.ghost.animationStatus.pathProgress >= progress && !stopShowingRace) {
-                animationControls.start({   // First, complete the lap
-                    offsetDistance: "100%",
-                    transition: { duration: 1.5 }
-                }).then((val) => {
-                    animationControls.set({   // Then, reset the progress to 0 so it doesn't travel from 100 backwards
-                        offsetDistance: "0%",
-                        transition: { delay: 1000 }
-                    })
-                }).then((val) => {
-                    animationControls.start({   // Finally, play the animation leading to the new progress value
-                        offsetDistance: progress.toString() + "%",
-                        transition: { duration: 1, delay: 0.5 }
-                    })
-                    updateGhostValues(currentTimeScoreIndex, currentGhostNewScore, progress)
-                })
-            }
-            else {
-                animationControls.start({   // Else, just update the progress normally
-                    offsetDistance: progress.toString() + "%",
-                    transition: { duration: 1.5 }
-                })
-                updateGhostValues(currentTimeScoreIndex, currentGhostNewScore, progress)
-            }
+
+            animationControls.start({  
+                offsetDistance: progress.toString() + "%",
+                transition: {duration: 2}
+            })
+            updateGhostValues(currentTimeScoreIndex, currentGhostNewScore, progress)
         }
     }, [startAnimation])
 

--- a/client/src/components/RaceThemes/RaceService.ts
+++ b/client/src/components/RaceThemes/RaceService.ts
@@ -68,13 +68,17 @@ export function getRacePathObject(trackPoints: PercentCoordinate[], containerWid
             )
         )
 
-        if (i != 0) svgPath += "L" // L means move to coordinates x y, e.g. L 1 2
-        svgPath +=
-            (points[i].x + 20).toString() +
-            " " +
-            (containerHeight - points[i].y - 20).toString() +
-            " "
+        if (i < trackPoints.length - 1) {
+            if (i != 0 ) svgPath += "L" // L means move to coordinates x y, e.g. L 1 2
+            svgPath +=
+                (points[i].x + 20).toString() +
+                " " +
+                (containerHeight - points[i].y - 20).toString() +
+                " "
+        }
     }
+
+    svgPath += "z"
 
     const components: Component[] = []
     let tracksLength = 0


### PR DESCRIPTION
- Make the looping animation utilize the path offset percentage-based value for the looping along the path (e.g. 130% to achieve 30% progress in the team's second lap)
- Adjust the SVG path construction to ensure the path is recognized as a loop, without which the offset progress percent doesn't work
- Ensure the new progress percentage is larger than previous, to prevent team moving backwards due to a miscalculation